### PR TITLE
intl extension doesn't sound to be mandatory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "php": ">=7.0",
         "ext-libxml": "*",
         "ext-simplexml": "*",
-        "ext-intl": "*",
         "monolog/monolog": "^1.24"
     },
     "require-dev" : {

--- a/lib/Ogone/ShaComposer/LegacyShaComposer.php
+++ b/lib/Ogone/ShaComposer/LegacyShaComposer.php
@@ -44,7 +44,7 @@ class LegacyShaComposer implements ShaComposer
      * @param array $parameters
      * @return string
      */
-    public function compose(array $parameters)
+    public function compose(array $parameters, $useLatinCharset = false)
     {
         $parameters = array_change_key_case($parameters, CASE_LOWER);
 

--- a/tests/Ogone/Tests/ShaComposer/FakeShaComposer.php
+++ b/tests/Ogone/Tests/ShaComposer/FakeShaComposer.php
@@ -20,7 +20,7 @@ class FakeShaComposer implements ShaComposer
 {
     const FAKESHASTRING = 'foo';
 
-    public function compose(array $responseParameters)
+    public function compose(array $responseParameters, $useLatinCharset = false)
     {
         return self::FAKESHASTRING;
     }


### PR DESCRIPTION
Hello,

Since there is a test on this https://github.com/limegrow/ogone-sdk-php/blob/master/lib/Ogone/ShaComposer/AllParametersShaComposer.php#L60 to check if the extension is loaded, the composer.json shouldn't require ext-lib.

I also fix ShaComposer implementation to respect compose interface signature